### PR TITLE
51 fix notification link protocol

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,2 +1,3 @@
 export const DEFAULT_LANG = 'en';
 export const DEFAULT_EXPORT_ACTIONS_VALIDITY_IN_DAYS = 7;
+export const DEFAULT_PROTOCOL = 'http';

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -34,8 +34,7 @@ export const buildIframeResizeHeightKey = ({
   memberId?: UUID;
   itemId: UUID;
 }) =>
-  `${COOKIE_KEYS.IFRAME_RESIZE_HEIGHT_KEY}-${memberId ?? 'unknown'
-  }-${itemId}`;
+  `${COOKIE_KEYS.IFRAME_RESIZE_HEIGHT_KEY}-${memberId ?? 'unknown'}-${itemId}`;
 
 /**
  * @returns {boolean} whether the user accepted the cookies

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,4 +1,5 @@
 import { MOCK_HOST, MOCK_ITEM_ID, MOCK_URL } from '../../test/fixtures';
+import { DEFAULT_PROTOCOL } from '../config';
 import * as cookieUtils from './cookie';
 import {
   buildItemLinkForBuilder,
@@ -70,21 +71,21 @@ describe('Navigation Util Tests', () => {
   describe('buildItemLinkForBuilder', () => {
     it('build item path without specifying chat status', () => {
       const res = buildItemLinkForBuilder({
-        host: MOCK_URL,
+        host: MOCK_HOST,
         itemId: MOCK_ITEM_ID,
       });
-      expect(res).toContain(MOCK_URL);
+      expect(res).toContain(MOCK_HOST);
       expect(res).toContain(MOCK_ITEM_ID);
       expect(res).not.toContain('chat=');
     });
 
     it('build item path with chat closed', () => {
       const res = buildItemLinkForBuilder({
-        host: MOCK_URL,
+        host: MOCK_HOST,
         itemId: MOCK_ITEM_ID,
         chatOpen: false,
       });
-      expect(res).toContain(MOCK_URL);
+      expect(res).toContain(MOCK_HOST);
       expect(res).toContain(MOCK_ITEM_ID);
       // query string should contain "chat=false" to have the chat closed
       expect(res).toContain('chat=false');
@@ -92,14 +93,33 @@ describe('Navigation Util Tests', () => {
 
     it('build item path with chat open', () => {
       const res = buildItemLinkForBuilder({
-        host: MOCK_URL,
+        host: MOCK_HOST,
         itemId: MOCK_ITEM_ID,
         chatOpen: true,
       });
-      expect(res).toContain(MOCK_URL);
+      expect(res).toContain(MOCK_HOST);
       expect(res).toContain(MOCK_ITEM_ID);
       // query string should contain "chat=true" to have the chat open
       expect(res).toContain('chat=true');
+    });
+
+    it('build item path with protocol', () => {
+      const res = buildItemLinkForBuilder({
+        host: MOCK_HOST,
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(DEFAULT_PROTOCOL);
+    });
+
+    it('build item path with special protocol', () => {
+      const specialProtocol = 'smb';
+      const res = buildItemLinkForBuilder({
+        protocol: specialProtocol,
+        host: MOCK_HOST,
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(specialProtocol);
+      expect(res).not.toContain(DEFAULT_PROTOCOL);
     });
   });
 });

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,11 +1,13 @@
 import qs from 'qs';
 
+import { DEFAULT_PROTOCOL } from '../config';
 import { getUrlForRedirection } from './cookie';
 
 interface RedirectOptions {
   openInNewTab?: boolean;
   name?: string;
 }
+
 /**
  * @param  {string} url link to redirect to
  * @param  {RedirectOptions} options
@@ -19,6 +21,7 @@ export const redirect = (url: string, options?: RedirectOptions) => {
     window.location.assign(url);
   }
 };
+
 /**
  * @param  {string} defaultLink link to redirect to if no url for redirection is defined
  * @param  {RedirectOptions} options
@@ -39,27 +42,32 @@ export const redirectToSavedUrl = (
 
   return false;
 };
+
 /**
  * @param  {string} host authentication host
  * @returns {string} sign in path
  */
 export const buildSignInPath = ({ host }: { host: string }) => `${host}/signin`;
+
 /**
+ * @param  {string} protocol target protocol to use (http, https ...)
  * @param  {string} host target host
  * @param  {string} itemId id of the item
  * @param  {boolean} chatOpen whether to have the chat open
  * @returns {string} link to item with chat open
  */
 export const buildItemLinkForBuilder = ({
+  protocol = DEFAULT_PROTOCOL,
   host,
   itemId,
   chatOpen,
 }: {
+  protocol?: string;
   host: string;
   itemId: string;
   chatOpen?: boolean;
 }) =>
-  `${host}/items/${itemId}${qs.stringify(
+  `${protocol}://${host}/items/${itemId}${qs.stringify(
     { chat: chatOpen },
     { addQueryPrefix: true },
   )}`;


### PR DESCRIPTION
This PR fixes the missing protocol in the builder method for the link to items in notification emails.

closes #51 