### PR TITLE
fix: deprecate host and protocol in `buildItemLinkForBuilder`

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_LANG = 'en';
 export const DEFAULT_EXPORT_ACTIONS_VALIDITY_IN_DAYS = 7;
-export const DEFAULT_PROTOCOL = 'http';
+export const DEFAULT_PROTOCOL = 'https';
+export const PROTO_REGEX = /https?:\/\//;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
 export const DEFAULT_LANG = 'en';
 export const DEFAULT_EXPORT_ACTIONS_VALIDITY_IN_DAYS = 7;
 export const DEFAULT_PROTOCOL = 'https';
-export const PROTO_REGEX = /https?:\/\//;
+export const PROTOCOL_REGEX = /https?:\/\//;

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,6 +1,6 @@
 import {
   MOCK_HOST,
-  MOCK_HOST_WITH_PROTO,
+  MOCK_HOST_WITH_PROTOCOL,
   MOCK_ITEM_ID,
   MOCK_URL,
 } from '../../test/fixtures';
@@ -129,10 +129,10 @@ describe('Navigation Util Tests', () => {
 
     it('build item path with host containing protocol', () => {
       const res = buildItemLinkForBuilder({
-        host: MOCK_HOST_WITH_PROTO,
+        host: MOCK_HOST_WITH_PROTOCOL,
         itemId: MOCK_ITEM_ID,
       });
-      expect(res).toContain(MOCK_HOST_WITH_PROTO);
+      expect(res).toContain(MOCK_HOST_WITH_PROTOCOL);
     });
   });
 
@@ -206,10 +206,10 @@ describe('Navigation Util Tests', () => {
 
     it('build item path with string origin', () => {
       const res = buildItemLinkForBuilder({
-        origin: MOCK_HOST_WITH_PROTO,
+        origin: MOCK_HOST_WITH_PROTOCOL,
         itemId: MOCK_ITEM_ID,
       });
-      expect(res).toContain(MOCK_HOST_WITH_PROTO);
+      expect(res).toContain(MOCK_HOST_WITH_PROTOCOL);
     });
   });
 });

--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -1,4 +1,9 @@
-import { MOCK_HOST, MOCK_ITEM_ID, MOCK_URL } from '../../test/fixtures';
+import {
+  MOCK_HOST,
+  MOCK_HOST_WITH_PROTO,
+  MOCK_ITEM_ID,
+  MOCK_URL,
+} from '../../test/fixtures';
 import { DEFAULT_PROTOCOL } from '../config';
 import * as cookieUtils from './cookie';
 import {
@@ -68,7 +73,7 @@ describe('Navigation Util Tests', () => {
     });
   });
 
-  describe('buildItemLinkForBuilder', () => {
+  describe('buildItemLinkForBuilder LEGACY', () => {
     it('build item path without specifying chat status', () => {
       const res = buildItemLinkForBuilder({
         host: MOCK_HOST,
@@ -120,6 +125,91 @@ describe('Navigation Util Tests', () => {
       });
       expect(res).toContain(specialProtocol);
       expect(res).not.toContain(DEFAULT_PROTOCOL);
+    });
+
+    it('build item path with host containing protocol', () => {
+      const res = buildItemLinkForBuilder({
+        host: MOCK_HOST_WITH_PROTO,
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(MOCK_HOST_WITH_PROTO);
+    });
+  });
+
+  describe('buildItemLinkForBuilder', () => {
+    it('build item path without specifying chat status', () => {
+      const res = buildItemLinkForBuilder({
+        origin: {
+          hostName: MOCK_HOST,
+          protocol: DEFAULT_PROTOCOL,
+        },
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(MOCK_HOST);
+      expect(res).toContain(MOCK_ITEM_ID);
+      expect(res).not.toContain('chat=');
+    });
+
+    it('build item path with chat closed', () => {
+      const res = buildItemLinkForBuilder({
+        origin: {
+          hostName: MOCK_HOST,
+          protocol: DEFAULT_PROTOCOL,
+        },
+        itemId: MOCK_ITEM_ID,
+        chatOpen: false,
+      });
+      expect(res).toContain(MOCK_HOST);
+      expect(res).toContain(MOCK_ITEM_ID);
+      // query string should contain "chat=false" to have the chat closed
+      expect(res).toContain('chat=false');
+    });
+
+    it('build item path with chat open', () => {
+      const res = buildItemLinkForBuilder({
+        origin: {
+          hostName: MOCK_HOST,
+          protocol: DEFAULT_PROTOCOL,
+        },
+        itemId: MOCK_ITEM_ID,
+        chatOpen: true,
+      });
+      expect(res).toContain(MOCK_HOST);
+      expect(res).toContain(MOCK_ITEM_ID);
+      // query string should contain "chat=true" to have the chat open
+      expect(res).toContain('chat=true');
+    });
+
+    it('build item path with protocol', () => {
+      const res = buildItemLinkForBuilder({
+        origin: {
+          hostName: MOCK_HOST,
+          protocol: DEFAULT_PROTOCOL,
+        },
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(DEFAULT_PROTOCOL);
+    });
+
+    it('build item path with special protocol', () => {
+      const specialProtocol = 'smb';
+      const res = buildItemLinkForBuilder({
+        origin: {
+          hostName: MOCK_HOST,
+          protocol: specialProtocol,
+        },
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(specialProtocol);
+      expect(res).not.toContain(DEFAULT_PROTOCOL);
+    });
+
+    it('build item path with string origin', () => {
+      const res = buildItemLinkForBuilder({
+        origin: MOCK_HOST_WITH_PROTO,
+        itemId: MOCK_ITEM_ID,
+      });
+      expect(res).toContain(MOCK_HOST_WITH_PROTO);
     });
   });
 });

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,6 +1,6 @@
 import qs from 'qs';
 
-import { DEFAULT_PROTOCOL, PROTO_REGEX } from '../config';
+import { DEFAULT_PROTOCOL, PROTOCOL_REGEX } from '../config';
 import { getUrlForRedirection } from './cookie';
 
 interface RedirectOptions {
@@ -92,7 +92,7 @@ export const buildItemLinkForBuilder: BuildItemLinkFunc = (
   } else {
     // todo: LEGACY code, will be removed once the Old type is removed
     // check if the host contains the protocol
-    const hostIncludesProto = args.host.match(PROTO_REGEX);
+    const hostIncludesProto = args.host.match(PROTOCOL_REGEX);
     if (hostIncludesProto) {
       origin = args.host;
     } else {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -9,3 +9,4 @@ export const MOCK_ITEM_ID = '1234';
 export const MOCK_LANG = 'en';
 
 export const MOCK_HOST = 'myhost';
+export const MOCK_HOST_WITH_PROTO = 'http://myhost.com';

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -9,4 +9,4 @@ export const MOCK_ITEM_ID = '1234';
 export const MOCK_LANG = 'en';
 
 export const MOCK_HOST = 'myhost';
-export const MOCK_HOST_WITH_PROTO = 'http://myhost.com';
+export const MOCK_HOST_WITH_PROTOCOL = 'http://myhost.com';


### PR DESCRIPTION
This PR deprecates the use of the `host` and `protocol` parameters in `buildItemLinkForBuilder`.
It introduces a new function signature with `origin` parameter which is either a string like `https://example.com` or an object with mandatory properties `{ hostName: string; protocol: string }`.

closes #54 