### PR TITLE
feat: add enableSaveActions property

### DIFF
--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -17,6 +17,7 @@ export interface ItemSettings extends Serializable {
   hasThumbnail?: boolean;
   isResizable?: boolean;
   isCollapsible?: boolean;
+  enableSaveActions?: boolean;
 }
 
 export type ItemBase<S = ItemSettings> = {

--- a/src/services/members/interfaces/member.ts
+++ b/src/services/members/interfaces/member.ts
@@ -19,4 +19,5 @@ export interface MemberExtra extends UnknownExtra {
   hasAvatar?: boolean;
   favoriteItems?: string[];
   lang?: string;
+  enableSaveActions?: boolean;
 }


### PR DESCRIPTION
This PR adds the enableSaveActions property in Member interface and ItemSettings interface, which will be used on GDPR.