### PR TITLE
feat: add ThumbnailSize to exported constants

### DIFF
--- a/src/frontend/index.ts
+++ b/src/frontend/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './ui';

--- a/src/frontend/ui.ts
+++ b/src/frontend/ui.ts
@@ -1,0 +1,11 @@
+/**
+ * Size of Thumbnail to use
+ */
+export const ThumbnailSize = {
+  SMALL: 'small',
+  MEDIUM: 'medium',
+  LARGE: 'large',
+  ORIGINAL: 'original',
+} as const;
+export type ThumbnailSizeVariant =
+  `${(typeof ThumbnailSize)[keyof typeof ThumbnailSize]}`;


### PR DESCRIPTION
This PR exports the `ThumbnailSize` constant enum to be used in `@graasp/ui`, `@graasp/query-client`, `@graasp/builder` and `@graasp/player`.

closes #99
