### PR TITLE
fix: add embedded link item settings

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,5 +2,3 @@
 export const SESSION_COOKIE_EXPIRATION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export const IFRAME_RESIZE_HEIGHT_COOKIE_EXPIRATION_DAYS = 365; // 365 days
-
-export const DEFAULT_LINK_SHOW_BUTTON = true;

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -2,3 +2,5 @@
 export const SESSION_COOKIE_EXPIRATION_DURATION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export const IFRAME_RESIZE_HEIGHT_COOKIE_EXPIRATION_DAYS = 365; // 365 days
+
+export const DEFAULT_LINK_SHOW_BUTTON = true;

--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -21,6 +21,11 @@ export interface ItemSettings extends Serializable {
   enableSaveActions?: boolean;
 }
 
+export interface EmbeddedLinkItemSettings extends ItemSettings {
+  showLinkIframe?: boolean;
+  showLinkButton?: boolean;
+}
+
 export interface Item<E = UnknownExtra, S = ItemSettings> {
   id: string;
   name: string;
@@ -53,6 +58,7 @@ export type H5PItemType<S = ItemSettings> = {
 export type EmbeddedLinkItemType<S = ItemSettings> = {
   type: `${ItemType.LINK}`;
   extra: EmbeddedLinkItemExtra;
+  settings: EmbeddedLinkItemSettings;
 } & Item<S>;
 export type LocalFileItemType<S = ItemSettings> = {
   type: `${ItemType.LOCAL_FILE}`;


### PR DESCRIPTION
This PR adds the embedded link item settings types to the discriminated item so we can have correct and accurate typing when accessing the EmbeddedLinkItem type. `showLinkButton` is now correctly typed as `boolean | undefined` when access inside a type guard on the item `type` property.