### PR TITLE
feat: add appendQueryParamToUrl

### DIFF
--- a/src/utils/navigation.test.ts
+++ b/src/utils/navigation.test.ts
@@ -7,6 +7,7 @@ import {
 import { DEFAULT_PROTOCOL } from '../config';
 import * as cookieUtils from './cookie';
 import {
+  appendQueryParamToUrl,
   buildItemLinkForBuilder,
   buildPdfViewerLink,
   buildSignInPath,
@@ -228,6 +229,32 @@ describe('Navigation Util Tests', () => {
     it('build url with asset url', () => {
       const res = buildPdfViewerLink(assetsUrl);
       expect(res).toContain(assetsUrl);
+    });
+  });
+
+  describe('appendQueryParamToUrl', () => {
+    it('return same url when params is empty', () => {
+      const initialUrl = 'http://localhost:3000/index.html';
+      const res = appendQueryParamToUrl(initialUrl, {});
+      expect(res).toEqual(initialUrl);
+    });
+
+    it('add params to url', () => {
+      const initialUrl = 'http://localhost:3000/index.html';
+      const res = appendQueryParamToUrl(initialUrl, { lang: 'en' });
+      expect(res).toEqual('http://localhost:3000/index.html?lang=en');
+    });
+
+    it('add params to url without overriding', () => {
+      const initialUrl = 'http://localhost:3000/index.html?lang=en';
+      const res = appendQueryParamToUrl(initialUrl, { lang: 'de' });
+      expect(res).toEqual('http://localhost:3000/index.html?lang=en&lang=de');
+    });
+
+    it('override params in url', () => {
+      const initialUrl = 'http://localhost:3000/index.html?lang=en&test=bobo';
+      const res = appendQueryParamToUrl(initialUrl, { lang: 'de' }, true);
+      expect(res).toEqual('http://localhost:3000/index.html?lang=de&test=bobo');
     });
   });
 });

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -113,3 +113,29 @@ export const buildItemLinkForBuilder: BuildItemLinkFunc = (
  */
 export const buildPdfViewerLink = (assetsUrl?: string) =>
   assetsUrl ? `https://${assetsUrl}/pdf-viewer/web/viewer.html?file=` : '';
+
+/**
+ * Utility method to append new query parameters to a url.
+ * The initial url is allowed to contain some query parameters already.
+ * Any key in the `params` argument will override the value of already present query parameters in `initialUrl`.
+ * @param initialUrl a string representing the url that you want to append queries to
+ * @param params an object of key values that should be added to the query string of the url
+ * @param overrideExisting a boolean that controls whether the keys in the `params` object
+ * should override existing keys or be added (default)
+ * @returns new string representing the url with added parameters
+ */
+export const appendQueryParamToUrl = (
+  initialUrl: string,
+  params: { [key: string]: string },
+  overrideExisting = false,
+): string => {
+  const url = new URL(initialUrl);
+  const queryString = new URLSearchParams(url.search);
+  Object.entries(params).forEach(([key, value]) =>
+    overrideExisting
+      ? queryString.set(key, value)
+      : queryString.append(key, value),
+  );
+  url.search = queryString.toString();
+  return url.toString();
+};


### PR DESCRIPTION
This PR adds a utility function to append queries to urls.

It also has an option to override existing keys. The default is to simply append new keys, keeping the ones that are already set.

