### PR TITLE
fix: allow optional domain on saveUrlForRedirection

### DIFF
--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -42,7 +42,7 @@ export const hasAcceptedCookies = () =>
  * @param  {string} link link to save for further redirection
  * @param  {string} domain value for the cookie's domain
  */
-export const saveUrlForRedirection = (link: string, domain: string) => {
+export const saveUrlForRedirection = (link: string, domain?: string) => {
   Cookies.set(COOKIE_KEYS.REDIRECT_URL_KEY, link, { domain, secure: true });
 };
 


### PR DESCRIPTION
This PR improves the type of the `saveUrlForRedirection` util function to allow the omission of the domain parameter. This parameter can be `undefined` and will then default to the current domain.
