### PR TITLE
fix(type): item.description to be nullable

### DIFF
--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -36,7 +36,7 @@ export interface EmbeddedLinkItemSettings extends ItemSettings {
 export interface Item<S = ItemSettings> {
   id: string;
   name: string;
-  description: string;
+  description: string | null;
   path: string;
   settings: S;
   creator: Member | null;


### PR DESCRIPTION
This PR updates the type of `Item` to reflect the nullable property of `description`.

This is correct with the item schema defined in the backend.
