### PR TITLE
fix: use `DiscriminatedItem` instead of `Item`

### DIFF
--- a/src/constants/itemType.ts
+++ b/src/constants/itemType.ts
@@ -1,15 +1,3 @@
-// export enum ItemType {
-//   APP = 'app',
-//   DOCUMENT = 'document',
-//   FOLDER = 'folder',
-//   LINK = 'embeddedLink',
-//   LOCAL_FILE = 'file',
-//   S3_FILE = 's3File',
-//   SHORTCUT = 'shortcut',
-//   H5P = 'h5p',
-//   ETHERPAD = 'etherpad',
-// }
-
 export enum ItemType {
   APP = 'app',
   DOCUMENT = 'document',

--- a/src/constants/itemType.ts
+++ b/src/constants/itemType.ts
@@ -1,3 +1,15 @@
+// export enum ItemType {
+//   APP = 'app',
+//   DOCUMENT = 'document',
+//   FOLDER = 'folder',
+//   LINK = 'embeddedLink',
+//   LOCAL_FILE = 'file',
+//   S3_FILE = 's3File',
+//   SHORTCUT = 'shortcut',
+//   H5P = 'h5p',
+//   ETHERPAD = 'etherpad',
+// }
+
 export enum ItemType {
   APP = 'app',
   DOCUMENT = 'document',
@@ -10,4 +22,4 @@ export enum ItemType {
   ETHERPAD = 'etherpad',
 }
 
-export type FileItemType = ItemType.S3_FILE | ItemType.LOCAL_FILE;
+export type FileItemType = typeof ItemType.S3_FILE | typeof ItemType.LOCAL_FILE;

--- a/src/services/action/interfaces.ts
+++ b/src/services/action/interfaces.ts
@@ -1,9 +1,9 @@
-import { Item, ItemMembership, Member } from '..';
+import { DiscriminatedItem, ItemMembership, Member } from '..';
 import { Context } from '@/constants';
 
 export interface Action {
   id: string;
-  item?: Item | null;
+  item?: DiscriminatedItem | null;
   member?: Member | null;
   view: Context | 'Unknown';
   type: string;
@@ -15,8 +15,8 @@ export interface Action {
 
 export interface ActionData {
   actions: Action[];
-  descendants: Item[];
-  item: Item;
+  descendants: DiscriminatedItem[];
+  item: DiscriminatedItem;
   itemMemberships: ItemMembership[];
   members: Member[];
   metadata: {

--- a/src/services/app/interfaces/appAction.ts
+++ b/src/services/app/interfaces/appAction.ts
@@ -1,8 +1,8 @@
-import { Item, Member } from '@/services';
+import { DiscriminatedItem, Member } from '@/services';
 
 export type AppAction = {
   id: string;
-  item: Item;
+  item: DiscriminatedItem;
   member: Member;
   type: string;
   data: object;

--- a/src/services/app/interfaces/appData.ts
+++ b/src/services/app/interfaces/appData.ts
@@ -1,18 +1,20 @@
-import { DiscriminatedItem, Item, Member } from '@/services';
+import { DiscriminatedItem, Member } from '@/services';
 
 export enum AppDataVisibility {
   Item = 'item',
   Member = 'member',
 }
 
-export type AppData = {
+type Data = { [key: string]: unknown };
+
+export type AppData<T extends Data = Data> = {
   id: string;
   item: DiscriminatedItem;
   creator: Member | null;
   member: Member;
   type: string;
   visibility: `${AppDataVisibility}` | AppDataVisibility;
-  data: { [key: string]: unknown };
+  data: T;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/services/app/interfaces/appData.ts
+++ b/src/services/app/interfaces/appData.ts
@@ -1,4 +1,4 @@
-import { Item, Member } from '@/services';
+import { DiscriminatedItem, Item, Member } from '@/services';
 
 export enum AppDataVisibility {
   Item = 'item',
@@ -7,7 +7,7 @@ export enum AppDataVisibility {
 
 export type AppData = {
   id: string;
-  item: Item;
+  item: DiscriminatedItem;
   creator: Member | null;
   member: Member;
   type: string;

--- a/src/services/app/interfaces/appSetting.ts
+++ b/src/services/app/interfaces/appSetting.ts
@@ -1,9 +1,9 @@
-import { Item, Member } from '@/services';
+import { DiscriminatedItem, Member } from '@/services';
 import { UUID } from '@/types';
 
 export type AppSetting = {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   creator?: Member | null;
   name: string;
   data: { [key: string]: unknown };

--- a/src/services/app/interfaces/appSetting.ts
+++ b/src/services/app/interfaces/appSetting.ts
@@ -1,12 +1,13 @@
 import { DiscriminatedItem, Member } from '@/services';
 import { UUID } from '@/types';
 
-export type AppSetting = {
+type Data = { [key: string]: unknown };
+export type AppSetting<T extends Data = Data> = {
   id: UUID;
   item: DiscriminatedItem;
   creator?: Member | null;
   name: string;
-  data: { [key: string]: unknown };
+  data: T;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/services/categories/types.ts
+++ b/src/services/categories/types.ts
@@ -1,4 +1,4 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { UUID } from '@/types';
 
 export enum CategoryType {
@@ -21,7 +21,7 @@ export type Category = {
 
 export type ItemCategory = {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   category: Category;
   createdAt: Date;
   creator: Member;

--- a/src/services/chat/types.ts
+++ b/src/services/chat/types.ts
@@ -1,4 +1,4 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { MentionStatus } from '@/constants/mentions';
 import { UUID } from '@/types';
 
@@ -6,7 +6,7 @@ import { UUID } from '@/types';
 
 export type ChatMessage = {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   creator: Member | null;
   createdAt: Date;
   updatedAt: Date;

--- a/src/services/flag/types.ts
+++ b/src/services/flag/types.ts
@@ -1,10 +1,10 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { UUID } from '@/types';
 
 export type ItemFlag = {
   id: UUID;
   type: `${FlagType}` | FlagType;
-  item: Item;
+  item: DiscriminatedItem;
   creator: Member;
   createdAt: Date;
 };

--- a/src/services/invitation/types.ts
+++ b/src/services/invitation/types.ts
@@ -1,4 +1,4 @@
-import { Item, Member, PermissionLevel } from '@/index';
+import { DiscriminatedItem, Member, PermissionLevel } from '@/index';
 import { UUID } from '@/types';
 
 export type Invitation = {
@@ -7,7 +7,7 @@ export type Invitation = {
   permission: PermissionLevel;
   name?: string;
   creator?: Member | null;
-  item: Item;
+  item: DiscriminatedItem;
   createdAt: Date;
   updatedAt: Date;
 };

--- a/src/services/item-like/types.ts
+++ b/src/services/item-like/types.ts
@@ -1,9 +1,9 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { UUID } from '@/types';
 
 export type ItemLike = {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   creator: Member;
   createdAt: Date;
 };

--- a/src/services/item-login/types.ts
+++ b/src/services/item-login/types.ts
@@ -1,9 +1,9 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { ItemLoginSchemaType, UUID } from '@/index';
 
 export interface ItemLoginSchema {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   type: `${ItemLoginSchemaType}` | ItemLoginSchemaType;
   createdAt: Date;
   updatedAt: Date;

--- a/src/services/item-memberships/interfaces/item-membership.ts
+++ b/src/services/item-memberships/interfaces/item-membership.ts
@@ -1,10 +1,10 @@
 import { PermissionLevel } from '../../../constants';
-import { Item, Member, UUID } from '@/index';
+import { DiscriminatedItem, Member, UUID } from '@/index';
 
 export interface ItemMembership {
   id: UUID;
   member: Member;
-  item: Item;
+  item: DiscriminatedItem;
   permission: PermissionLevel;
   creator?: Member | null;
   createdAt: Date;

--- a/src/services/item-published/types.ts
+++ b/src/services/item-published/types.ts
@@ -1,10 +1,10 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { UUID } from '@/types';
 
 export interface ItemPublished {
   id: UUID;
   creator?: Member;
   createdAt: Date;
-  item: Item;
+  item: DiscriminatedItem;
   totalViews: number;
 }

--- a/src/services/item-recycled/types.ts
+++ b/src/services/item-recycled/types.ts
@@ -1,8 +1,8 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 
 export type RecycledItemData = {
   id: string;
   creator: Member;
   createdAt: Date;
-  item: Item;
+  item: DiscriminatedItem;
 };

--- a/src/services/item-tags/types.ts
+++ b/src/services/item-tags/types.ts
@@ -1,4 +1,4 @@
-import { Item, Member } from '../index';
+import { DiscriminatedItem, Member } from '../index';
 import { UUID } from '@/types';
 
 export enum ItemTagType {
@@ -8,7 +8,7 @@ export enum ItemTagType {
 
 export type ItemTag = {
   id: UUID;
-  item: Item;
+  item: DiscriminatedItem;
   type: `${ItemTagType}` | ItemTagType;
   createdAt: Date;
   creator: Member;

--- a/src/services/item-validation/types.ts
+++ b/src/services/item-validation/types.ts
@@ -1,4 +1,4 @@
-import { Item, Member } from '..';
+import { DiscriminatedItem, Member } from '..';
 
 export enum ItemValidationStatus {
   Success = 'success',
@@ -21,7 +21,7 @@ export enum ItemValidationReviewStatus {
 
 export interface ItemValidation {
   id: string;
-  item: Item;
+  item: DiscriminatedItem;
   process: `${ItemValidationProcess}` | ItemValidationProcess;
   status: `${ItemValidationStatus}` | ItemValidationStatus;
   result: string;
@@ -32,7 +32,7 @@ export interface ItemValidation {
 
 export interface ItemValidationGroup {
   id: string;
-  item: Item;
+  item: DiscriminatedItem;
   createdAt: Date;
   itemValidations: ItemValidation[];
 }

--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -25,23 +25,23 @@ export interface Item<S = ItemSettings> {
 }
 
 export type AppItemType<S = ItemSettings> = {
-  type: `${ItemType.APP}`;
+  type: typeof ItemType.APP;
   extra: AppItemExtra;
 } & Item<S>;
 export type DocumentItemType<S = ItemSettings> = {
-  type: `${ItemType.DOCUMENT}`;
+  type: typeof ItemType.DOCUMENT;
   extra: DocumentItemExtra;
 } & Item<S>;
 export type FolderItemType<S = ItemSettings> = {
-  type: `${ItemType.FOLDER}`;
+  type: typeof ItemType.FOLDER;
   extra: FolderItemExtra;
 } & Item<S>;
 export type H5PItemType<S = ItemSettings> = {
-  type: `${ItemType.H5P}`;
+  type: typeof ItemType.H5P;
   extra: H5PItemExtra;
 } & Item<S>;
 export type EmbeddedLinkItemType<S = ItemSettings> = {
-  type: `${ItemType.LINK}`;
+  type: typeof ItemType.LINK;
   extra: EmbeddedLinkItemExtra;
   settings: EmbeddedLinkItemSettings;
 } & Item<S>;
@@ -54,11 +54,11 @@ export type S3FileItemType = {
   extra: S3FileItemExtra;
 } & Item<FileItemSettings>;
 export type ShortcutItemType<S = ItemSettings> = {
-  type: `${ItemType.SHORTCUT}`;
+  type: typeof ItemType.SHORTCUT;
   extra: ShortcutItemExtra;
 } & Item<S>;
 export type EtherpadItemType<S = ItemSettings> = {
-  type: `${ItemType.ETHERPAD}`;
+  type: typeof ItemType.ETHERPAD;
   extra: EtherpadItemExtra;
 } & Item<S>;
 

--- a/src/services/items/interfaces/item.ts
+++ b/src/services/items/interfaces/item.ts
@@ -25,23 +25,23 @@ export interface Item<S = ItemSettings> {
 }
 
 export type AppItemType<S = ItemSettings> = {
-  type: typeof ItemType.APP;
+  type: `${ItemType.APP}`;
   extra: AppItemExtra;
 } & Item<S>;
 export type DocumentItemType<S = ItemSettings> = {
-  type: typeof ItemType.DOCUMENT;
+  type: `${ItemType.DOCUMENT}`;
   extra: DocumentItemExtra;
 } & Item<S>;
 export type FolderItemType<S = ItemSettings> = {
-  type: typeof ItemType.FOLDER;
+  type: `${ItemType.FOLDER}`;
   extra: FolderItemExtra;
 } & Item<S>;
 export type H5PItemType<S = ItemSettings> = {
-  type: typeof ItemType.H5P;
+  type: `${ItemType.H5P}`;
   extra: H5PItemExtra;
 } & Item<S>;
 export type EmbeddedLinkItemType<S = ItemSettings> = {
-  type: typeof ItemType.LINK;
+  type: `${ItemType.LINK}`;
   extra: EmbeddedLinkItemExtra;
   settings: EmbeddedLinkItemSettings;
 } & Item<S>;
@@ -54,11 +54,11 @@ export type S3FileItemType = {
   extra: S3FileItemExtra;
 } & Item<FileItemSettings>;
 export type ShortcutItemType<S = ItemSettings> = {
-  type: typeof ItemType.SHORTCUT;
+  type: `${ItemType.SHORTCUT}`;
   extra: ShortcutItemExtra;
 } & Item<S>;
 export type EtherpadItemType<S = ItemSettings> = {
-  type: typeof ItemType.ETHERPAD;
+  type: `${ItemType.ETHERPAD}`;
   extra: EtherpadItemExtra;
 } & Item<S>;
 

--- a/src/services/members/interfaces/member.ts
+++ b/src/services/members/interfaces/member.ts
@@ -17,6 +17,12 @@ export interface Member {
   id: UUID;
   name: string;
   email: string;
+}
+
+export interface CurrentMember {
+  id: UUID;
+  name: string;
+  email: string;
   type: `${MemberType}` | MemberType;
   extra: MemberExtra;
   createdAt: Date;

--- a/src/services/members/interfaces/member.ts
+++ b/src/services/members/interfaces/member.ts
@@ -19,7 +19,7 @@ export interface Member {
   email: string;
 }
 
-export interface CurrentMember {
+export interface CompleteMember {
   id: UUID;
   name: string;
   email: string;

--- a/src/services/members/interfaces/member.ts
+++ b/src/services/members/interfaces/member.ts
@@ -5,26 +5,23 @@ export enum MemberType {
   Group = 'group',
 }
 
-export interface MemberExtra {
+export type MemberExtra = {
   hasAvatar?: boolean;
   lang?: string;
   enableSaveActions?: boolean;
   emailFreq?: `${EmailFrequency}` | EmailFrequency;
   hasCompletedTour?: boolean;
-}
+};
 
-export interface Member {
+export type Member = {
   id: UUID;
   name: string;
   email: string;
-}
+};
 
-export interface CompleteMember {
-  id: UUID;
-  name: string;
-  email: string;
+export type CompleteMember = Member & {
   type: `${MemberType}` | MemberType;
   extra: MemberExtra;
   createdAt: Date;
   updatedAt: Date;
-}
+};

--- a/src/utils/extra.ts
+++ b/src/utils/extra.ts
@@ -20,56 +20,56 @@ import { ImmutableCast } from '@/frontend/types';
 export const getFileExtra = <
   U extends LocalFileItemExtra | ImmutableCast<LocalFileItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.LOCAL_FILE] | undefined => extra?.[ItemType.LOCAL_FILE];
+  extra: U,
+): U[typeof ItemType.LOCAL_FILE] => extra[ItemType.LOCAL_FILE];
 
 export const getFolderExtra = <
   U extends FolderItemExtra | ImmutableCast<FolderItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.FOLDER] | undefined => extra?.[ItemType.FOLDER];
+  extra: U,
+): U[typeof ItemType.FOLDER] => extra[ItemType.FOLDER];
 
 export const getShortcutExtra = <
   U extends ShortcutItemExtra | ImmutableCast<ShortcutItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.SHORTCUT] | undefined => extra?.[ItemType.SHORTCUT];
+  extra: U,
+): U[typeof ItemType.SHORTCUT] => extra[ItemType.SHORTCUT];
 
 export const getEtherpadExtra = <
   U extends EtherpadItemExtra | ImmutableCast<EtherpadItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.ETHERPAD] | undefined => extra?.[ItemType.ETHERPAD];
+  extra: U,
+): U[typeof ItemType.ETHERPAD] => extra[ItemType.ETHERPAD];
 
 export const getS3FileExtra = <
   U extends S3FileItemExtra | ImmutableCast<S3FileItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.S3_FILE] | undefined => extra?.[ItemType.S3_FILE];
+  extra: U,
+): U[typeof ItemType.S3_FILE] => extra[ItemType.S3_FILE];
 
 export const getEmbeddedLinkExtra = <
   U extends EmbeddedLinkItemExtra | ImmutableCast<EmbeddedLinkItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.LINK] | undefined => extra?.[ItemType.LINK];
+  extra: U,
+): U[typeof ItemType.LINK] => extra[ItemType.LINK];
 
 export const getDocumentExtra = <
   U extends DocumentItemExtra | ImmutableCast<DocumentItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.DOCUMENT] | undefined => extra?.[ItemType.DOCUMENT];
+  extra: U,
+): U[typeof ItemType.DOCUMENT] => extra[ItemType.DOCUMENT];
 
 export const getAppExtra = <
   U extends AppItemExtra | ImmutableCast<AppItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.APP] | undefined => extra?.[ItemType.APP];
+  extra: U,
+): U[typeof ItemType.APP] => extra[ItemType.APP];
 
 export const getH5PExtra = <
   U extends H5PItemExtra | ImmutableCast<H5PItemExtra>,
 >(
-  extra?: U,
-): U[ItemType.H5P] | undefined => extra?.[ItemType.H5P];
+  extra: U,
+): U[typeof ItemType.H5P] => extra[ItemType.H5P];
 
 export const buildDocumentExtra = (
   document: DocumentItemExtraProperties,

--- a/src/utils/extra.ts
+++ b/src/utils/extra.ts
@@ -21,55 +21,55 @@ export const getFileExtra = <
   U extends LocalFileItemExtra | ImmutableCast<LocalFileItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.LOCAL_FILE] => extra[ItemType.LOCAL_FILE];
+): U[ItemType.LOCAL_FILE] => extra[ItemType.LOCAL_FILE];
 
 export const getFolderExtra = <
   U extends FolderItemExtra | ImmutableCast<FolderItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.FOLDER] => extra[ItemType.FOLDER];
+): U[ItemType.FOLDER] => extra[ItemType.FOLDER];
 
 export const getShortcutExtra = <
   U extends ShortcutItemExtra | ImmutableCast<ShortcutItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.SHORTCUT] => extra[ItemType.SHORTCUT];
+): U[ItemType.SHORTCUT] => extra[ItemType.SHORTCUT];
 
 export const getEtherpadExtra = <
   U extends EtherpadItemExtra | ImmutableCast<EtherpadItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.ETHERPAD] => extra[ItemType.ETHERPAD];
+): U[ItemType.ETHERPAD] => extra[ItemType.ETHERPAD];
 
 export const getS3FileExtra = <
   U extends S3FileItemExtra | ImmutableCast<S3FileItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.S3_FILE] => extra[ItemType.S3_FILE];
+): U[ItemType.S3_FILE] => extra[ItemType.S3_FILE];
 
 export const getEmbeddedLinkExtra = <
   U extends EmbeddedLinkItemExtra | ImmutableCast<EmbeddedLinkItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.LINK] => extra[ItemType.LINK];
+): U[ItemType.LINK] => extra[ItemType.LINK];
 
 export const getDocumentExtra = <
   U extends DocumentItemExtra | ImmutableCast<DocumentItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.DOCUMENT] => extra[ItemType.DOCUMENT];
+): U[ItemType.DOCUMENT] => extra[ItemType.DOCUMENT];
 
 export const getAppExtra = <
   U extends AppItemExtra | ImmutableCast<AppItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.APP] => extra[ItemType.APP];
+): U[ItemType.APP] => extra[ItemType.APP];
 
 export const getH5PExtra = <
   U extends H5PItemExtra | ImmutableCast<H5PItemExtra>,
 >(
   extra: U,
-): U[typeof ItemType.H5P] => extra[ItemType.H5P];
+): U[ItemType.H5P] => extra[ItemType.H5P];
 
 export const buildDocumentExtra = (
   document: DocumentItemExtraProperties,


### PR DESCRIPTION
This PR updates the types to use `DiscriminatedItem` instead of `Item`.

This way the Record type of the key `item` will match `ItemRecord` since `ItemRecord` derives from `DiscriminatedItem` and not  `Item`.

close #270 