### PR TITLE
feat(types): add `Optional<T, K>` utility type to make some properties of a type optional

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,5 @@ export type ResultOf<T> = {
   };
   errors: Error[];
 };
+
+export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;


### PR DESCRIPTION
This PR adds a utility type `Optional<T, K>` that combines `Omit` and `Pick` to make some properties of the input type optional.

We use this in a lot of our inputs in query-client and so on to allow some keys to be undefined and then throw an error of they are.

This utility will help to abstract that base type away and provide a nice type to work with
