### PR TITLE
fix: remove `UnknownExtra`

### DIFF
--- a/src/interfaces/extra.ts
+++ b/src/interfaces/extra.ts
@@ -1,9 +1,5 @@
 import { ItemType } from '../constants';
 
-export interface UnknownExtra {
-  [key: string]: unknown;
-}
-
 /**
  * Document style flavor defined according to severity prop of
  * https://mui.com/material-ui/react-alert/
@@ -22,7 +18,7 @@ export type DocumentItemExtraProperties = {
   flavor?: DocumentItemExtraFlavor | `${DocumentItemExtraFlavor}`;
 };
 
-export interface DocumentItemExtra extends UnknownExtra {
+export interface DocumentItemExtra {
   [ItemType.DOCUMENT]: DocumentItemExtraProperties;
 }
 
@@ -33,7 +29,7 @@ export type EmbeddedLinkItemExtraProperties = {
   icons?: string[];
 };
 
-export interface EmbeddedLinkItemExtra extends UnknownExtra {
+export interface EmbeddedLinkItemExtra {
   [ItemType.LINK]: EmbeddedLinkItemExtraProperties;
 }
 
@@ -42,7 +38,7 @@ export type FolderItemExtraProperties = {
   isRoot?: boolean;
 };
 
-export interface FolderItemExtra extends UnknownExtra {
+export interface FolderItemExtra {
   [ItemType.FOLDER]: FolderItemExtraProperties;
 }
 
@@ -50,6 +46,6 @@ export type ShortcutItemExtraProperties = {
   target: string;
 };
 
-export interface ShortcutItemExtra extends UnknownExtra {
+export interface ShortcutItemExtra {
   [ItemType.SHORTCUT]: ShortcutItemExtraProperties;
 }

--- a/src/services/app/interfaces/extra.ts
+++ b/src/services/app/interfaces/extra.ts
@@ -3,7 +3,7 @@ import { ItemType } from '../../../constants';
 export type AppItemExtraProperties = {
   url: string;
   // todo: there currently is nothing stored in the settings. this might change later
-  settings?: object;
+  settings?: unknown;
 };
 
 export interface AppItemExtra {

--- a/src/services/app/interfaces/extra.ts
+++ b/src/services/app/interfaces/extra.ts
@@ -1,11 +1,11 @@
 import { ItemType } from '../../../constants';
-import { UnknownExtra } from '../../../interfaces';
 
 export type AppItemExtraProperties = {
   url: string;
-  settings?: UnknownExtra;
+  // todo: there currently is nothing stored in the settings. this might change later
+  settings?: object;
 };
 
-export interface AppItemExtra extends UnknownExtra {
+export interface AppItemExtra {
   [ItemType.APP]: AppItemExtraProperties;
 }

--- a/src/services/etherpad/interfaces/etherpad.ts
+++ b/src/services/etherpad/interfaces/etherpad.ts
@@ -1,5 +1,4 @@
 import { ItemType } from '../../../constants';
-import { UnknownExtra } from '@/index';
 
 /**
  * This type refers to the result sent by the server when querying
@@ -14,6 +13,6 @@ export type EtherpadItemExtraProperties = {
   groupID: string;
 };
 
-export interface EtherpadItemExtra extends UnknownExtra {
+export interface EtherpadItemExtra {
   [ItemType.ETHERPAD]: EtherpadItemExtraProperties;
 }

--- a/src/services/file/interfaces/extra.ts
+++ b/src/services/file/interfaces/extra.ts
@@ -1,5 +1,4 @@
 import { ItemType } from '../../../constants';
-import { UnknownExtra } from '../../../interfaces';
 
 /**
  * @deprecated Use FileItemProperties instead
@@ -19,11 +18,11 @@ export type FileItemProperties = {
   content: string;
 };
 
-export interface LocalFileItemExtra extends UnknownExtra {
+export interface LocalFileItemExtra {
   [ItemType.LOCAL_FILE]: FileItemProperties;
 }
 
-export interface S3FileItemExtra extends UnknownExtra {
+export interface S3FileItemExtra {
   [ItemType.S3_FILE]: FileItemProperties;
 }
 

--- a/src/services/h5p/interfaces/extra.ts
+++ b/src/services/h5p/interfaces/extra.ts
@@ -1,5 +1,4 @@
 import { ItemType } from '../../../constants';
-import { UnknownExtra } from '../../../interfaces';
 
 export type H5PItemExtraProperties = {
   /** storage ID */
@@ -10,6 +9,6 @@ export type H5PItemExtraProperties = {
   contentFilePath: string;
 };
 
-export interface H5PItemExtra extends UnknownExtra {
+export interface H5PItemExtra {
   [ItemType.H5P]: H5PItemExtraProperties;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "CommonJS",
+    "module": "node16",
     "outDir": "dist",
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -18,12 +18,8 @@
     "strictNullChecks": true,
     "baseUrl": "./src",
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
-  "include": [
-    "src/**/*"
-  ],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
In this PR I remove the `UnknownExtra` to enforce stronger types and remove errors with types generalizing to `[x: string]: unknown` in TS.