### PR TITLE
fix: remove ClientHostManager instantiation in the SDK

### DIFF
--- a/src/constants/host.ts
+++ b/src/constants/host.ts
@@ -3,10 +3,3 @@ export const BUILDER_ITEMS_PREFIX = '/items';
 export const PLAYER_ITEMS_PREFIX = '';
 export const LIBRARY_ITEMS_PREFIX = '/collections';
 export const ANALYTICS_ITEMS_PREFIX = '/items';
-
-// Default Graasp hosts
-export const PROD_BUILDER_HOST = 'https://builder.graasp.org/';
-export const PROD_PLAYER_HOST = 'https://player.graasp.org/';
-export const PROD_LIBRARY_HOST = 'https://library.graasp.org/';
-export const PROD_ANALYTICS_HOST = 'https://analytics.graasp.org/';
-export const PROD_SHORT_LINK_HOST = 'https://go.graasp.org/';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,6 @@
-import {
-  ANALYTICS_ITEMS_PREFIX,
-  BUILDER_ITEMS_PREFIX,
-  LIBRARY_ITEMS_PREFIX,
-  PLAYER_ITEMS_PREFIX,
-  PROD_ANALYTICS_HOST,
-  PROD_BUILDER_HOST,
-  PROD_LIBRARY_HOST,
-  PROD_PLAYER_HOST,
-} from './constants';
-import { Context } from './constants/context';
-import { ClientHostManager } from './interfaces/shortLink';
-
 export * from './utils';
 export * from './constants';
 export * from './interfaces';
 export * from './services';
 export * from './config';
 export * from './types';
-
-// Instanciate and add prefix and default host for the diffrent contexts.
-ClientHostManager.getInstance()
-  .addPrefix(Context.Builder, BUILDER_ITEMS_PREFIX)
-  .addPrefix(Context.Library, LIBRARY_ITEMS_PREFIX)
-  .addPrefix(Context.Player, PLAYER_ITEMS_PREFIX)
-  .addPrefix(Context.Analytics, ANALYTICS_ITEMS_PREFIX)
-  .addHost(Context.Builder, new URL(PROD_BUILDER_HOST))
-  .addHost(Context.Library, new URL(PROD_LIBRARY_HOST))
-  .addHost(Context.Player, new URL(PROD_PLAYER_HOST))
-  .addHost(Context.Analytics, new URL(PROD_ANALYTICS_HOST));

--- a/src/interfaces/shortLink.ts
+++ b/src/interfaces/shortLink.ts
@@ -49,8 +49,8 @@ export class ClientHostManager {
     );
   }
 
-  public addHost(context: Context, host: URL, replace: boolean = false) {
-    if (!replace && this.clientHosts.has(context)) {
+  public addHost(context: Context, host: URL) {
+    if (this.clientHosts.has(context)) {
       throw new Error(
         `The given context '${context}' is already present in the hosts.`,
       );


### PR DESCRIPTION
The ClientHostManager was instanced  in the SDK to set default Hosts and Prefix. 
The problem is its add a side effect. Indeed, each time the SDK is imported, a ClientHostManager a new instance is created.

To avoid this unexpected side effect, the instantiation is removed from the SDK and must be done in the backend for example.