### PR TITLE
Update the short link's payload from item to itemId

### DIFF
--- a/src/interfaces/shortLink.ts
+++ b/src/interfaces/shortLink.ts
@@ -22,6 +22,9 @@ export type ShortLinkPatchPayload = AnyOfExcept<
   'createdAt' | 'item'
 >;
 export type ShortLinkPutPayload = Omit<ShortLink, 'createdAt' | 'item'>;
+export type ShortLinkAvailable = {
+  available: boolean;
+};
 
 export class ClientHostManager {
   private static INSTANCE: ClientHostManager | null;

--- a/src/interfaces/shortLink.ts
+++ b/src/interfaces/shortLink.ts
@@ -94,10 +94,14 @@ export class ClientHostManager {
     return { host: new URL(host), prefix };
   }
 
-  public getItemLink(context: Context, itemId: string) {
+  public getItemAsURL(context: Context, itemId: string) {
     const host = this.getHost(context);
     const prefix = this.getPrefix(context);
     const url = new URL(`${prefix}/${itemId}`, host.origin);
     return url;
+  }
+
+  public getItemLink(context: Context, itemId: string) {
+    return this.getItemAsURL(context, itemId).toString();
   }
 }

--- a/src/interfaces/shortLink.ts
+++ b/src/interfaces/shortLink.ts
@@ -16,12 +16,15 @@ export type ShortLink = {
   createdAt: string;
 };
 
-export type ShortLinkPostPayload = Omit<ShortLink, 'createdAt'>;
-export type ShortLinkPatchPayload = AnyOfExcept<
-  ShortLink,
-  'createdAt' | 'item'
->;
-export type ShortLinkPutPayload = Omit<ShortLink, 'createdAt' | 'item'>;
+export type ShortLinkItemId = {
+  itemId: string;
+};
+
+export type ShortLinkPayload = Omit<ShortLink, 'createdAt' | 'item'> &
+  ShortLinkItemId;
+export type ShortLinkPostPayload = ShortLinkPayload;
+export type ShortLinkPatchPayload = AnyOfExcept<ShortLinkPostPayload, 'itemId'>;
+export type ShortLinkPutPayload = Omit<ShortLinkPayload, 'itemId'>;
 export type ShortLinkAvailable = {
   available: boolean;
 };


### PR DESCRIPTION
This PR update the payload of short links to allow to send directly the item id like: `{..., itemId: "..." } instead of {..., item: { id: ... } }`. 

This updates simplify the usage of the API and increase clarity because it's avoid to send incomplete item.
The transformation from itemId to item is done in the backend directly.