### PR TITLE
feat: add address in geolocation

### DIFF
--- a/src/services/item-geolocation/types.ts
+++ b/src/services/item-geolocation/types.ts
@@ -7,6 +7,7 @@ export type ItemGeolocation = {
   lng: number;
   item: DiscriminatedItem;
   country: string | null;
+  address: string | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/src/services/item-geolocation/types.ts
+++ b/src/services/item-geolocation/types.ts
@@ -7,7 +7,7 @@ export type ItemGeolocation = {
   lng: number;
   item: DiscriminatedItem;
   country: string | null;
-  address: string | null;
+  addressLabel: string | null;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
I still keep the country besides so it's easier to query per country.
I could have plenty of rows for the address (eg. road, state, country_code, postal_code, etc) but they just look infinite so I just the default label string I was provided. I think it's still okay to keep it simple as we're not planning (yet) complex geolocation search.