### PR TITLE
fix(build): split bundle into production and test code

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,25 +1,32 @@
 {
   "name": "@graasp/sdk",
   "version": "3.8.1",
-  "license": "AGPL-3.0-only",
-  "repository": "git@github.com:graasp/graasp-sdk.git",
+  "description": "Development kit including type definitions and util functions for the Graasp ecosystem.",
   "author": "Graasp",
   "contributors": [
     "Kim Lan Phan Hoang",
     "Basile Spaenlehauer"
   ],
+  "license": "AGPL-3.0-only",
+  "repository": "git@github.com:graasp/graasp-sdk.git",
   "type": "module",
-  "sideEffects": false,
   "files": [
     "dist"
   ],
-  "main": "./dist/index.cjs",
+  "sideEffects": false,
   "module": "./dist/index.js",
+  "main": "./dist/index.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./factories": {
+      "import": "./dist/factories.js",
+      "require": "./dist/factories.cjs",
+      "types": "./dist/factories.d.ts"
     }
   },
   "scripts": {
@@ -32,9 +39,9 @@
     "check": "yarn prettier:check && yarn lint && yarn type-check",
     "pre-commit": "yarn prettier:check && yarn lint",
     "prepack": "yarn build",
-    "prepare": "yarn prepack && yarn hooks:install",
-    "hooks:install": "husky install",
-    "hooks:uninstall": "husky uninstall"
+    "prepare": "yarn prepack && yarn hooks",
+    "hooks": "husky",
+    "analyze-bundle": "npx vite-bundle-visualizer"
   },
   "dependencies": {
     "@faker-js/faker": "8.4.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prettier:check": "prettier --check src/**/*.ts",
     "prettier:write": "prettier --write src/**/*.ts",
     "check": "yarn prettier:check && yarn lint && yarn type-check",
+    "analyze-bundle": "npx vite-bundle-visualizer",
     "pre-commit": "yarn prettier:check && yarn lint",
     "prepack": "yarn build",
     "prepare": "yarn prepack && yarn hooks",

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "pre-commit": "yarn prettier:check && yarn lint",
     "prepack": "yarn build",
     "prepare": "yarn prepack && yarn hooks",
-    "hooks": "husky",
-    "analyze-bundle": "npx vite-bundle-visualizer"
+    "hooks": "husky"
   },
   "dependencies": {
     "@faker-js/faker": "8.4.0",

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -1,0 +1,2 @@
+export { MemberFactory } from './services/members/memberFactory';
+export * from './services/items/itemFactory';

--- a/src/services/items/index.ts
+++ b/src/services/items/index.ts
@@ -1,3 +1,2 @@
 export * from './interfaces/item';
 export * from './interfaces/itemSettings';
-export * from './itemFactory';

--- a/src/services/items/itemFactory.test.ts
+++ b/src/services/items/itemFactory.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { MemberFactory } from '../members/memberFactory';
 import {
   AppItemFactory,
   DocumentItemFactory,
@@ -10,8 +11,7 @@ import {
   LocalFileItemFactory,
   S3FileItemFactory,
   ShortcutItemFactory,
-} from '.';
-import { MemberFactory } from '../members/memberFactory';
+} from './itemFactory';
 import { ItemType } from '@/constants';
 
 describe('ItemFactor General', () => {

--- a/src/services/members/index.ts
+++ b/src/services/members/index.ts
@@ -1,4 +1,3 @@
 export * from './interfaces/member';
 export * from './interfaces/storage';
 export * from './interfaces/password';
-export * from './memberFactory';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,13 +23,13 @@
 
     "types": ["vite/client"],
     "paths": {
-      "@/*": ["./src/*"],
+      "@/*": ["./src/*"]
     },
 
     "noImplicitThis": true,
     "noImplicitAny": true,
-    "strictNullChecks": true,
+    "strictNullChecks": true
   },
   "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }],
+  "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,11 +16,12 @@ export default (): UserConfigExport => {
     build: {
       lib: {
         // Could also be a dictionary or array of multiple entry points
-        entry: resolve(__dirname, 'src/index.ts'),
+        entry: [
+          resolve(__dirname, 'src/index.ts'),
+          resolve(__dirname, 'src/factories.ts'),
+        ],
         name: 'graasp-sdk',
         formats: ['cjs', 'es'],
-        // the proper extensions will be added
-        fileName: 'index',
       },
       rollupOptions: {
         // make sure to externalize deps that shouldn't be bundled


### PR DESCRIPTION
In this PR:
- in order to reduce bundle size when used by consumers, the factories have been moved to a separate entry-point `@graasp/sdk/factories`
- using this import only in test files should reduce the bundle size of the client apps while allowing to keep the factories in this repo.