### PR TITLE
fix: add redirection Url in sign in path

### DIFF
--- a/src/navigation/navigation.test.ts
+++ b/src/navigation/navigation.test.ts
@@ -73,8 +73,17 @@ describe('Navigation Util Tests', () => {
 
   describe('buildSignInPath', () => {
     it('build sign in path', () => {
-      const res = buildSignInPath({ host: MOCK_HOST });
-      expect(res).toContain(MOCK_HOST);
+      const res = buildSignInPath({ host: MOCK_HOST_WITH_PROTOCOL });
+      expect(res).toContain(MOCK_HOST_WITH_PROTOCOL);
+    });
+    it('build sign in path with redirection url', () => {
+      const redirectionUrl = 'https://test.com';
+      const res = buildSignInPath({
+        host: MOCK_HOST_WITH_PROTOCOL,
+        redirectionUrl,
+      });
+      expect(res).toContain(MOCK_HOST_WITH_PROTOCOL);
+      expect(res).toContain(`?url=${encodeURIComponent(redirectionUrl)}`);
     });
   });
 

--- a/src/navigation/navigation.ts
+++ b/src/navigation/navigation.ts
@@ -63,7 +63,19 @@ export const redirectToSavedUrl = (
  * @param  {string} host authentication host (Graasp Auth)
  * @returns {string} absolute url for the sign in path
  */
-export const buildSignInPath = ({ host }: { host: string }) => `${host}/signin`;
+export const buildSignInPath = ({
+  host,
+  redirectionUrl,
+}: {
+  host: string;
+  redirectionUrl?: string;
+}) => {
+  const url = new URL('/signin', host);
+  if (redirectionUrl) {
+    url.searchParams.set('url', redirectionUrl);
+  }
+  return url.toString();
+};
 
 /**
  * Build the absolute url to view an item in the builder with optional parameter to specify whether the chat is open


### PR DESCRIPTION
In this PR:
- add redirection Url option in sign in path. This allows to redirect users to where they were when they need to sign in again.
- fix #449 
