### PR TITLE
fix: add username constants

### DIFF
--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -70,8 +70,8 @@ export const MAX_ITEM_NAME_LENGTH = 500 as const;
 /**
  * Maximum username length
  */
-export const MAX_USERNAME_LENGTH = 100 as const;
+export const MAX_USERNAME_LENGTH = 60 as const;
 /**
  * Minimum username length
  */
-export const MIN_USERNAME_LENGTH = 3 as const;
+export const MIN_USERNAME_LENGTH = 2 as const;

--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -66,3 +66,12 @@ export const MAX_THUMBNAIL_SIZE = 10 * 1024 * 1024;
  * Maximum item name length
  */
 export const MAX_ITEM_NAME_LENGTH = 500 as const;
+
+/**
+ * Maximum username length
+ */
+export const MAX_USERNAME_LENGTH = 100 as const;
+/**
+ * Minimum username length
+ */
+export const MIN_USERNAME_LENGTH = 1 as const;

--- a/src/constants/limits.ts
+++ b/src/constants/limits.ts
@@ -74,4 +74,4 @@ export const MAX_USERNAME_LENGTH = 100 as const;
 /**
  * Minimum username length
  */
-export const MIN_USERNAME_LENGTH = 1 as const;
+export const MIN_USERNAME_LENGTH = 3 as const;


### PR DESCRIPTION
In this PR I add the username constants for validation. They are used in Auth and Account.
The values are taken from the backend:
- in the schema for the MIN: 1
- in the entity for the MAX: 100
fix #478 