### PR TITLE
feat: set item's license setting nullable

### DIFF
--- a/src/item/itemSettings.ts
+++ b/src/item/itemSettings.ts
@@ -3,6 +3,7 @@ import {
   OldCCLicenseAdaptations,
 } from '@/enums/ccLicenses.js';
 import { DescriptionPlacementType } from '@/enums/descriptionPlacement.js';
+import { Nullable } from '@/typeUtils.js';
 
 export interface ItemSettings {
   /** @deprecated use item.lang */
@@ -15,10 +16,12 @@ export interface ItemSettings {
   enableSaveActions?: boolean;
   tags?: string[];
   displayCoEditors?: boolean;
-  ccLicenseAdaption?:
+  // allow null to delete setting in the backend
+  ccLicenseAdaption?: Nullable<
     | `${CCLicenseAdaptions}`
     | CCLicenseAdaptions
     // TODO: these are the old licenses, we might remove them at some point.
-    | `${OldCCLicenseAdaptations}`;
+    | `${OldCCLicenseAdaptations}`
+  >;
   descriptionPlacement?: DescriptionPlacementType;
 }

--- a/src/typeUtils.ts
+++ b/src/typeUtils.ts
@@ -29,9 +29,23 @@ export type AnyOf<T> = {
   [K in keyof T]: Pick<T, K>;
 }[keyof T];
 
-// TODO: add usage informations
-
 /**
  * This allow to define a type with at least one attribute of T that is not a key in E.
+ *
+ * The following type add usage informations about:
+ * `type ShortLinkPatchPayload = AnyOfExcept<ShortLinkPostPayload, 'itemId'>;`
+ * - The `itemId` is not allowed.
+ * - All other attributes of ShortLinkPostPayload are allowed and optional.
+ * - At least of attribute is required.
  */
 export type AnyOfExcept<T, E extends keyof T> = AnyOf<Omit<T, E>>;
+
+/**
+ * The type is T or null.
+ *
+ * - `type NullableString = Nullable<string>`:
+ *   - `const nullableString: NullableString<string> = "my string";`
+ *   - `const nullableString: NullableString<string> = null;`
+ * - `type NullableMultipleType = Nullable<string | boolean | number>`:
+ */
+export type Nullable<T> = T | null;


### PR DESCRIPTION
- Allows item's license setting to be null.
- Sending null to the backend will remove the setting.