### PR TITLE
fix: add description on link extra properties

### DIFF
--- a/src/item/linkItem/linkItem.ts
+++ b/src/item/linkItem/linkItem.ts
@@ -12,10 +12,32 @@ export type LinkItemType<S = ItemSettings> = {
  * Link Extra
  */
 export type LinkItemExtraProperties = {
-  thumbnails?: string[];
-  html?: string;
+  /**
+   * Link URl
+   */
   url: string;
+  /**
+   * Contains automatic thumbnails for the page, usually better used for large cards or banners
+   */
+  thumbnails?: string[];
+  /**
+   * Contains automatic icons for the page, usually better used as thumbnails as they
+   * are commonly extracted from the favicon of the site
+   */
   icons?: string[];
+  /**
+   * HTML integration code for rich media
+   * Usually contains code that loads a media player for Youtube videos etc.
+   *
+   * Should not be editable by users as it is directly used and can't be sanitized as
+   * it would remove the integration code/iframe
+   */
+  html?: string;
+  /**
+   * Contains automatic page description extracted
+   * Used to be displayed in fancy link card, or anywhere the original website description is needed
+   */
+  description?: string;
 };
 export interface LinkItemExtra {
   [ItemType.LINK]: LinkItemExtraProperties;


### PR DESCRIPTION
In this PR I add a `description` property to the link extra to allow storing the automatic page description for later re-use in the fancy card.