### PR TITLE
feat: create permission table

### DIFF
--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+
+import { Operation, can } from './permissions.js';
+import { PermissionLevel } from '@/enums/permissionLevel/permissionLevel.js';
+import { PackedFolderItemFactory } from '@/item/folderItem/folderItem.factory.js';
+import { MemberFactory } from '@/member/factory.js';
+import { MemberType } from '@/member/member.js';
+
+const privateItem = PackedFolderItemFactory({}, { permission: null });
+const privateItemWithAdmin = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Admin },
+);
+const privateItemWithWrite = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Write },
+);
+const privateItemWithRead = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Read },
+);
+const publicItem = PackedFolderItemFactory(
+  {},
+  { permission: null, publicTag: {} },
+);
+const publicItemWithAdmin = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Admin, publicTag: {} },
+);
+const publicItemWithWrite = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Admin, publicTag: {} },
+);
+const publicItemWithRead = PackedFolderItemFactory(
+  {},
+  { permission: PermissionLevel.Read, publicTag: {} },
+);
+
+const signedInMember = MemberFactory();
+// TODO: to change
+const pseudonymizedMember = MemberFactory({ type: MemberType.Group });
+
+describe('can', () => {
+  it(Operation.CopyItem + ' and signed in', () => {
+    expect(can(Operation.CopyItem, privateItem, signedInMember)).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithAdmin, signedInMember),
+    ).toBeTruthy();
+    expect(
+      can(Operation.CopyItem, privateItemWithWrite, signedInMember),
+    ).toBeTruthy();
+    expect(
+      can(Operation.CopyItem, privateItemWithRead, signedInMember),
+    ).toBeTruthy();
+    expect(can(Operation.CopyItem, publicItem, signedInMember)).toBeTruthy();
+    expect(
+      can(Operation.CopyItem, publicItemWithAdmin, signedInMember),
+    ).toBeTruthy();
+    expect(
+      can(Operation.CopyItem, publicItemWithWrite, signedInMember),
+    ).toBeTruthy();
+    expect(
+      can(Operation.CopyItem, publicItemWithRead, signedInMember),
+    ).toBeTruthy();
+  });
+  it(Operation.CopyItem + ' and signed out', () => {
+    expect(can(Operation.CopyItem, privateItem, undefined)).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithAdmin, undefined),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithWrite, undefined),
+    ).toBeFalsy();
+    expect(can(Operation.CopyItem, privateItemWithRead, undefined)).toBeFalsy();
+    expect(can(Operation.CopyItem, publicItem, undefined)).toBeFalsy();
+    expect(can(Operation.CopyItem, publicItemWithAdmin, undefined)).toBeFalsy();
+    expect(can(Operation.CopyItem, publicItemWithWrite, undefined)).toBeFalsy();
+    expect(can(Operation.CopyItem, publicItemWithRead, undefined)).toBeFalsy();
+  });
+  it(Operation.CopyItem + ' and pseudonimized', () => {
+    expect(
+      can(Operation.CopyItem, privateItem, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithAdmin, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithWrite, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, privateItemWithRead, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, publicItem, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, publicItemWithAdmin, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, publicItemWithWrite, pseudonymizedMember),
+    ).toBeFalsy();
+    expect(
+      can(Operation.CopyItem, publicItemWithRead, pseudonymizedMember),
+    ).toBeFalsy();
+  });
+
+  it(Operation.ReadItem + ' and pseudonimzed', () => {
+    expect(
+      can(Operation.ReadItem, privateItem, pseudonymizedMember),
+    ).toBeTruthy();
+    expect(
+      can(Operation.ReadItem, publicItem, pseudonymizedMember),
+    ).toBeTruthy();
+  });
+});

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -1,0 +1,92 @@
+import { PackedItem } from '@/item/packedItem.js';
+import { CompleteMember, MemberType } from '@/member/member.js';
+
+// TODO: reuse action op?
+export enum Operation {
+  ReadItem = 'read-item',
+  MoveItem = 'move-item',
+  CopyItem = 'copy-item',
+  HideItem = 'hide-item',
+  DownloadItem = 'download-item',
+}
+
+// don't take into account hidden: suppose backend will prevent read from beginning
+// pseudonymized users cannot create items and can only view a specific item
+const SIGNED_IN_OPERATIONS_PERMISSIONS = {
+  [Operation.ReadItem]: {
+    admin: true,
+    write: true,
+    read: true,
+    pseudonymized: true,
+    public: true,
+  },
+  [Operation.CopyItem]: {
+    admin: true,
+    write: true,
+    read: true,
+    pseudonymized: false,
+    public: true,
+  },
+  [Operation.MoveItem]: {
+    admin: true,
+    write: true,
+    read: false,
+    pseudonymized: false,
+    public: false,
+  },
+  [Operation.DownloadItem]: {
+    admin: true,
+    write: true,
+    read: true,
+    pseudonymized: true,
+    public: true,
+  },
+  [Operation.HideItem]: {
+    admin: true,
+    write: true,
+    read: false,
+    pseudonymized: false,
+    public: false,
+  },
+};
+
+const SIGNED_OUT_OPERATIONS_PERMISSIONS = {
+  [Operation.ReadItem]: {
+    public: true,
+  },
+  [Operation.CopyItem]: {
+    public: false,
+  },
+  [Operation.MoveItem]: {
+    public: false,
+  },
+  [Operation.DownloadItem]: {
+    public: true,
+  },
+  [Operation.HideItem]: {
+    public: false,
+  },
+};
+
+export const can = (
+  operation: Operation,
+  item: PackedItem,
+  member?: CompleteMember,
+) => {
+  // TODO: correct
+  const isPseudoMember = member?.type !== MemberType.Individual;
+
+  if (!member) {
+    const p = SIGNED_OUT_OPERATIONS_PERMISSIONS[operation];
+    return item.public ? p.public : false;
+  }
+
+  let permissionKey = item.permission;
+  if (isPseudoMember) {
+    permissionKey = 'pseudonymized';
+  } else if (!item.permission && item.public) {
+    permissionKey = 'public';
+  }
+
+  return SIGNED_IN_OPERATIONS_PERMISSIONS[operation]?.[permissionKey] ?? false;
+};


### PR DESCRIPTION
This is a draft: it still looks messy. The goal would be to centralized the permission so it's not always "deduced" by the frontend. 

The idea would be to allow it to be used:
```js
const shouldShow = can(COPY, item, member)

if(!shouldShow) { 
  return null
  // or
  return <You don't have the permission to perform this op>
}

return <div/>

```
Instead of having many ways to check the permissions

```js

// create app data - only signed in member can create data
const shouldShow = Boolean(member)
// copy, create - only signed in member (and not pseudo) can copy
const shouldShow = Boolean(member && member !== PSEUDO)
// hide item - at least write, the front needs to always remember which permission is required
const shouldShow = PermissionLevelCompare.gte(permission, WRITE)

if(!shouldShow) { 
  return null
  // or
  return <You don't have the permission to perform this op>
}

return <div/>

```


Questions:
- could this be used in the backend?