### PR TITLE
fix: remove extra.app.settings key in item

### DIFF
--- a/src/item/appItem/appItem.factory.test.ts
+++ b/src/item/appItem/appItem.factory.test.ts
@@ -12,7 +12,6 @@ describe('AppItemFactory', () => {
   it('Create app item', () => {
     const item = AppItemFactory();
     expect(item.extra.app.url).toContain('http');
-    expect(item.extra.app.settings).toBeDefined();
     expect(item.type).toEqual(ItemType.APP);
   });
   it('Create app item with args', () => {

--- a/src/item/appItem/appItem.factory.ts
+++ b/src/item/appItem/appItem.factory.ts
@@ -19,7 +19,6 @@ export const AppItemFactory = (
     extra: item.extra ?? {
       [ItemType.APP]: {
         url: faker.internet.url(),
-        settings: {},
       },
     },
   };

--- a/src/item/appItem/appItem.ts
+++ b/src/item/appItem/appItem.ts
@@ -12,12 +12,10 @@ export type AppItemType<S = ItemSettings> = {
  */
 export type AppItemExtraProperties = {
   url: string;
-  // todo: there currently is nothing stored in the settings. this might change later
-  settings?: unknown;
 };
-export interface AppItemExtra {
+export type AppItemExtra = {
   [ItemType.APP]: AppItemExtraProperties;
-}
+};
 
 export const getAppExtra = <U extends AppItemExtra>(
   extra: U,
@@ -25,9 +23,8 @@ export const getAppExtra = <U extends AppItemExtra>(
 
 export const buildAppExtra = ({
   url,
-  settings = {},
 }: AppItemExtraProperties): AppItemExtra => ({
-  [ItemType.APP]: { url, settings },
+  [ItemType.APP]: { url },
 });
 
 /**


### PR DESCRIPTION
In this PR I removed the unused `item.extra.app.settings` property.

This property was unused and we did not need it. It was typed as `unknown` which made some castings necessary in the backend. 

If we want to keep it, we should instead opt for a generic type that extends the empty object. 