### PR TITLE
feat: add support for AAC, FLAC, OGG and m4a

### DIFF
--- a/src/mimeTypes/mimeTypes.ts
+++ b/src/mimeTypes/mimeTypes.ts
@@ -20,11 +20,15 @@ const Audio = {
   MPEG: 'audio/mpeg',
   MP3: 'audio/mp3',
   AAC: 'audio/aac',
+  AAC_Adts: 'audio/vnd.dlna.adts',
   WAV: 'audio/wav',
   WAV_Chrome: 'audio/x-wav',
   MP4: 'audio/mp4',
   // this is the mimetype of audio files created in macOS, basically an audio file in an MPEG-4 container
   MP4_Apple: 'audio/x-m4a',
+  OGG: 'audio/ogg',
+  FLAC: 'audio/flac',
+  FLAC_Chrome: 'audio/x-flac',
 };
 
 const PDF = 'application/pdf';

--- a/src/mimeTypes/mimeTypes.ts
+++ b/src/mimeTypes/mimeTypes.ts
@@ -19,6 +19,7 @@ const Video = {
 const Audio = {
   MPEG: 'audio/mpeg',
   MP3: 'audio/mp3',
+  AAC: 'audio/aac',
   WAV: 'audio/wav',
   WAV_Chrome: 'audio/x-wav',
   MP4: 'audio/mp4',

--- a/src/mimeTypes/mimeTypes.ts
+++ b/src/mimeTypes/mimeTypes.ts
@@ -21,6 +21,9 @@ const Audio = {
   MP3: 'audio/mp3',
   WAV: 'audio/wav',
   WAV_Chrome: 'audio/x-wav',
+  MP4: 'audio/mp4',
+  // this is the mimetype of audio files created in macOS, basically an audio file in an MPEG-4 container
+  MP4_Apple: 'audio/x-m4a',
 };
 
 const PDF = 'application/pdf';


### PR DESCRIPTION
In this PR I add support for the audio files that use the `.m4a` file extension, that are detected as `audio/x-m4a`.