### PR TITLE
feat: improve getChildFromPath time complexity

### DIFF
--- a/src/item/itemUtils.test.ts
+++ b/src/item/itemUtils.test.ts
@@ -69,10 +69,34 @@ describe('Item Utils', () => {
 
   describe('getChildFromPath', () => {
     it('extract child id', () => {
+      const ancestor = v4();
       const parent = v4();
       const child = v4();
+      expect(getChildFromPath(buildPathFromIds(ancestor, parent, child))).toBe(
+        child,
+      );
       expect(getChildFromPath(buildPathFromIds(parent, child))).toBe(child);
       expect(getChildFromPath(buildPathFromIds(child))).toBe(child);
+    });
+    it('check execution time', () => {
+      const times = [];
+
+      for (let i = 0; i < 100; i++) {
+        const ids = Array.from({ length: 10000 }, () => v4());
+        const lastId = ids[ids.length - 1];
+        const path = buildPathFromIds(...ids);
+
+        const start = Date.now();
+        const fetchedId = getChildFromPath(path);
+        const end = Date.now();
+        times.push(end - start);
+        expect(fetchedId).toBe(lastId);
+      }
+
+      // Check median time
+      times.sort((a, b) => a - b);
+      const median = times[Math.floor(times.length / 2)];
+      expect(median).toBeLessThan(3);
     });
   });
 

--- a/src/item/itemUtils.ts
+++ b/src/item/itemUtils.ts
@@ -1,5 +1,6 @@
 import { DiscriminatedItem } from './item.js';
 
+const UUID_LENGTH = 36;
 /**
  * Returns the item path given an array of ids
  * @param ids consecutive item ids
@@ -35,8 +36,8 @@ export function getParentFromPath(itemPath: string): string | undefined {
  * @returns children ids
  */
 export function getChildFromPath(itemPath: string): string {
-  const ids = getIdsFromPath(itemPath);
-  return ids[ids.length - 1];
+  const id = itemPath.substring(itemPath.length - UUID_LENGTH);
+  return id.replace(/_/g, '-');
 }
 
 /**


### PR DESCRIPTION
The median time on `1'000` execution on my machine for a random path of `10'000` ids went from 5ms to 2ms.

I know it's not a big improvement, but I feel like I'm using this function a lot and it could be easily faster.