### PR TITLE
feat: add legacy member key in app types

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -70,7 +70,7 @@ export type AppSetting<T extends Data = Data> = {
 };
 
 export type LocalContext = {
-  accountId: UUID;
+  accountId?: UUID;
   /** @deprecated use accountId */
   memberId?: UUID;
   apiHost: string;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -71,6 +71,8 @@ export type AppSetting<T extends Data = Data> = {
 
 export type LocalContext = {
   accountId: UUID;
+  /** @deprecated use accountId */
+  memberId?: UUID;
   apiHost: string;
   context: 'standalone' | `${Context}`;
   dev?: boolean;

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,6 @@
 import { Publisher } from './publisher.js';
+import { Context } from '@/enums/context.js';
+import { PermissionLevel } from '@/enums/permissionLevel/permissionLevel.js';
 import { DiscriminatedItem } from '@/item/item.js';
 import { Account, Member } from '@/member/member.js';
 import { UUID } from '@/types.js';
@@ -65,4 +67,18 @@ export type AppSetting<T extends Data = Data> = {
   data: T;
   createdAt: string;
   updatedAt: string;
+};
+
+export type LocalContext = {
+  accountId: UUID;
+  apiHost: string;
+  context: 'standalone' | `${Context}`;
+  dev?: boolean;
+  itemId: UUID;
+  lang?: string;
+  mobile?: boolean;
+  offline?: boolean;
+  permission: PermissionLevel;
+  settings?: unknown;
+  standalone?: boolean;
 };


### PR DESCRIPTION
To avoid apps to break (we don't have control on some of them) we will set back the `member` key so they can continue to work.