### PR TITLE
fix(type): move ThumbnailSizeInPackedItem in thumbnailSizes to avoid any

### DIFF
--- a/src/enums/thumbnailSizes.ts
+++ b/src/enums/thumbnailSizes.ts
@@ -10,3 +10,13 @@ export const ThumbnailSize = {
   Original: 'original',
 } as const;
 export type ThumbnailSizeType = UnionOfConst<typeof ThumbnailSize>;
+
+// This type is defined here in the same file as ThumbnailSize.
+// Indeed, if defined in PackedItem, the transpiled type contains any.
+export const ThumbnailSizeInPackedItem = {
+  [ThumbnailSize.Small]: ThumbnailSize.Small,
+  [ThumbnailSize.Medium]: ThumbnailSize.Medium,
+} as const;
+export type ThumbnailsBySize = {
+  [thumbnailSize in UnionOfConst<typeof ThumbnailSizeInPackedItem>]: string;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,8 @@ export { MentionStatus, EmailFrequency } from './chat/mentions.js';
 export {
   ThumbnailSize,
   type ThumbnailSizeType,
+  ThumbnailSizeInPackedItem,
+  type ThumbnailsBySize,
 } from './enums/thumbnailSizes.js';
 
 /**
@@ -120,11 +122,7 @@ export * from './enums/alignment.js';
  */
 export { type DiscriminatedItem, getMimetype } from './item/item.js';
 export * from './item/itemSettings.js';
-export {
-  type PackedItem,
-  ThumbnailSizeInPackedItem,
-  type ThumbnailsBySize,
-} from './item/packedItem.js';
+export { type PackedItem } from './item/packedItem.js';
 export * from './item/itemType.js';
 export * from './item/itemUtils.js';
 export * from './item/events/itemFeedbackOperationEvent.js';

--- a/src/item/packedItem.ts
+++ b/src/item/packedItem.ts
@@ -1,17 +1,8 @@
 import { ItemMembership } from '../itemMembership/itemMembership.js';
 import { DiscriminatedItem } from './item.js';
 import { ItemSettings } from './itemSettings.js';
-import { ThumbnailSize } from '@/enums/thumbnailSizes.js';
+import { ThumbnailsBySize } from '@/enums/thumbnailSizes.js';
 import { ItemTag } from '@/itemTag/itemTag.js';
-import { UnionOfConst } from '@/typeUtils.js';
-
-export const ThumbnailSizeInPackedItem = {
-  [ThumbnailSize.Small]: ThumbnailSize.Small,
-  [ThumbnailSize.Medium]: ThumbnailSize.Medium,
-} as const;
-export type ThumbnailsBySize = {
-  [thumbnailSize in UnionOfConst<typeof ThumbnailSizeInPackedItem>]: string;
-};
 
 export type PackedInformation = {
   permission: ItemMembership['permission'] | null;


### PR DESCRIPTION
I decided to move back the `ThumbnailSizeInPackedItem` in the `thumbnailSizes.ts` to avoid transpiling weird type in commonJS (no issue with ESM).

![image](https://github.com/user-attachments/assets/8b771ff0-9ab3-45b3-90c1-953f449f89dd)

![image](https://github.com/user-attachments/assets/1bace1d9-910c-49b5-814f-0058e3f70895)
