### PR TITLE
fix: update member type to be able to use string litteral

### DIFF
--- a/src/itemMembership/itemMembership.ts
+++ b/src/itemMembership/itemMembership.ts
@@ -5,10 +5,10 @@ import { UUID } from '@/types.js';
 
 type AugmentedAccount =
   | (Member & {
-      type: AccountType.Individual;
+      type: `${AccountType.Individual}`;
     })
   | (Account & {
-      type: AccountType.Guest;
+      type: `${AccountType.Guest}`;
     });
 
 export interface ItemMembership {

--- a/src/member/member.ts
+++ b/src/member/member.ts
@@ -70,17 +70,16 @@ export type CompleteAccount = Account & {
 };
 
 export type CompleteMember = CompleteAccount & {
-  type: AccountType.Individual;
+  type: `${AccountType.Individual}`;
   email: string;
   extra: MemberExtra;
   enableSaveActions: boolean;
   userAgreementsDate?: string;
-
   isValidated: boolean;
 };
 
 export type CompleteGuest = CompleteAccount & {
-  type: AccountType.Guest;
+  type: `${AccountType.Guest}`;
   itemLoginSchema: ItemLoginSchema;
 };
 


### PR DESCRIPTION
This will allow using the string litteral for the `type` property of a member. Other wise we have to use the enum for typescript to be happy.