### PR TITLE
feat: make own validation for password

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
   "dependencies": {
     "@faker-js/faker": "9.2.0",
     "filesize": "10.1.6",
-    "js-cookie": "3.0.5",
-    "validator": "13.12.0"
+    "js-cookie": "3.0.5"
   },
   "peerDependencies": {
     "date-fns": "^3 || ^4.0.0",
@@ -61,7 +60,6 @@
     "@types/eslint": "^9.6.1",
     "@types/js-cookie": "3.0.6",
     "@types/uuid": "10.0.0",
-    "@types/validator": "13.12.2",
     "@typescript-eslint/eslint-plugin": "8.11.0",
     "@typescript-eslint/parser": "8.11.0",
     "date-fns": "4.1.0",

--- a/src/member/password.ts
+++ b/src/member/password.ts
@@ -1,7 +1,7 @@
-import validator from 'validator';
+import { isStrongPassword } from '@/validation/isPasswordStrong.js';
 
 export const isPasswordStrong = (password: string) =>
-  validator.isStrongPassword(password, {
+  isStrongPassword(password, {
     minLength: 8,
     minLowercase: 1,
     minUppercase: 1,

--- a/src/validation/isPasswordStrong.test.ts
+++ b/src/validation/isPasswordStrong.test.ts
@@ -1,6 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, test } from 'vitest';
 
 import { isStrongPassword } from './isPasswordStrong.js';
+
+const defaultOptions = {
+  minLength: 8,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 1,
+  minSymbols: 1,
+};
 
 describe('isStrongPassword', () => {
   it('not a strong password', () => {
@@ -21,5 +29,29 @@ describe('isStrongPassword', () => {
   });
   it('password is strong', () => {
     expect(isStrongPassword('aTest0!zu', {})).toBeTruthy();
+  });
+
+  test.each([
+    '%2%k{7BsL"M%Kd6e',
+    'EXAMPLE of very long_password123!',
+    'mxH_+2vs&54_+H3P',
+    '+&DxJ=X7-4L8jRCD',
+    'etV*p%Nr6w&H%FeF',
+    '£3.ndSau_7',
+    'VaLIDWith\\Symb0l',
+  ])('valid password "%s"', (value) => {
+    expect(isStrongPassword(value, defaultOptions)).toBeTruthy();
+  });
+
+  test.each([
+    '',
+    'password',
+    'hunter2',
+    'hello world',
+    'passw0rd',
+    'password!',
+    'PASSWORD!',
+  ])('invalid password "%s"', (value) => {
+    expect(isStrongPassword(value, defaultOptions)).toBeFalsy();
   });
 });

--- a/src/validation/isPasswordStrong.test.ts
+++ b/src/validation/isPasswordStrong.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { isStrongPassword } from './isPasswordStrong.js';
+
+describe('isStrongPassword', () => {
+  it('not a strong password', () => {
+    expect(isStrongPassword('', {})).toBeFalsy();
+  });
+  it('uses default values when not given', () => {
+    expect(isStrongPassword('a', { minLength: 1 })).toBeFalsy();
+    // need to specify all values for the password to be strong in this setting
+    expect(
+      isStrongPassword('a', {
+        minLength: 1,
+        minLowercase: 0,
+        minUppercase: 0,
+        minNumbers: 0,
+        minSymbols: 0,
+      }),
+    ).toBeTruthy();
+  });
+  it('password is strong', () => {
+    expect(isStrongPassword('aTest0!zu', {})).toBeTruthy();
+  });
+});

--- a/src/validation/isPasswordStrong.ts
+++ b/src/validation/isPasswordStrong.ts
@@ -6,8 +6,8 @@ import { countChars, merge } from './utils.js';
 
 const upperCaseRegex = /^[A-Z]$/;
 const lowerCaseRegex = /^[a-z]$/;
-const numberRegex = /^[0-9]$/;
-const symbolRegex = /^[-#!$@£%^&*()_+|~=`{}\[\]:";'<>?,.\/\\ ]$/;
+const numberRegex = /^\d$/;
+const symbolRegex = /^[-#!$@£%^&*()_+|~=`{}[\]:";'<>?,./\\ ]$/;
 
 const defaultOptions = {
   minLength: 8,

--- a/src/validation/isPasswordStrong.ts
+++ b/src/validation/isPasswordStrong.ts
@@ -1,3 +1,7 @@
+/**
+ * This code was adapted from the `validator.js` package
+ * https://github.com/validatorjs/validator.js/tree/master
+ */
 import { countChars, merge } from './utils.js';
 
 const upperCaseRegex = /^[A-Z]$/;

--- a/src/validation/isPasswordStrong.ts
+++ b/src/validation/isPasswordStrong.ts
@@ -1,0 +1,98 @@
+import { countChars, merge } from './utils.js';
+
+const upperCaseRegex = /^[A-Z]$/;
+const lowerCaseRegex = /^[a-z]$/;
+const numberRegex = /^[0-9]$/;
+const symbolRegex = /^[-#!$@£%^&*()_+|~=`{}\[\]:";'<>?,.\/\\ ]$/;
+
+const defaultOptions = {
+  minLength: 8,
+  minLowercase: 1,
+  minUppercase: 1,
+  minNumbers: 1,
+  minSymbols: 1,
+  returnScore: false,
+  pointsPerUnique: 1,
+  pointsPerRepeat: 0.5,
+  pointsForContainingLower: 10,
+  pointsForContainingUpper: 10,
+  pointsForContainingNumber: 10,
+  pointsForContainingSymbol: 10,
+};
+type PasswordOptions = typeof defaultOptions;
+
+type PasswordAnalysis = {
+  length: number;
+  uniqueChars: number;
+  uppercaseCount: number;
+  lowercaseCount: number;
+  numberCount: number;
+  symbolCount: number;
+};
+
+/* Return information about a password */
+function analyzePassword(password: string): PasswordAnalysis {
+  const charMap = countChars(password);
+  const analysis = {
+    length: password.length,
+    uniqueChars: Object.keys(charMap).length,
+    uppercaseCount: 0,
+    lowercaseCount: 0,
+    numberCount: 0,
+    symbolCount: 0,
+  };
+  Object.keys(charMap).forEach((char) => {
+    /* istanbul ignore else */
+    if (upperCaseRegex.test(char)) {
+      analysis.uppercaseCount += charMap[char];
+    } else if (lowerCaseRegex.test(char)) {
+      analysis.lowercaseCount += charMap[char];
+    } else if (numberRegex.test(char)) {
+      analysis.numberCount += charMap[char];
+    } else if (symbolRegex.test(char)) {
+      analysis.symbolCount += charMap[char];
+    }
+  });
+  return analysis;
+}
+
+function scorePassword(
+  analysis: PasswordAnalysis,
+  scoringOptions: PasswordOptions,
+): number {
+  let points = 0;
+  points += analysis.uniqueChars * scoringOptions.pointsPerUnique;
+  points +=
+    (analysis.length - analysis.uniqueChars) * scoringOptions.pointsPerRepeat;
+  if (analysis.lowercaseCount > 0) {
+    points += scoringOptions.pointsForContainingLower;
+  }
+  if (analysis.uppercaseCount > 0) {
+    points += scoringOptions.pointsForContainingUpper;
+  }
+  if (analysis.numberCount > 0) {
+    points += scoringOptions.pointsForContainingNumber;
+  }
+  if (analysis.symbolCount > 0) {
+    points += scoringOptions.pointsForContainingSymbol;
+  }
+  return points;
+}
+
+export function isStrongPassword(
+  str: string,
+  options: Partial<PasswordOptions>,
+) {
+  const analysis = analyzePassword(str);
+  const newOptions = merge(options || {}, defaultOptions);
+  if (newOptions.returnScore) {
+    return scorePassword(analysis, newOptions);
+  }
+  return (
+    analysis.length >= newOptions.minLength &&
+    analysis.lowercaseCount >= newOptions.minLowercase &&
+    analysis.uppercaseCount >= newOptions.minUppercase &&
+    analysis.numberCount >= newOptions.minNumbers &&
+    analysis.symbolCount >= newOptions.minSymbols
+  );
+}

--- a/src/validation/utils.test.ts
+++ b/src/validation/utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { countChars, merge } from './utils.js';
+
+describe('countChars', () => {
+  it('count empty string', () => {
+    expect(countChars('')).toEqual({});
+  });
+  it('count small string', () => {
+    expect(countChars('abcd')).toEqual({ a: 1, b: 1, c: 1, d: 1 });
+  });
+  it('count repeating string', () => {
+    expect(countChars('aaaaaaaaaa')).toEqual({ a: 10 });
+  });
+  it('count string with spaces', () => {
+    expect(countChars(' aaaaaaaaaa ')).toEqual({ a: 10, ' ': 2 });
+  });
+});
+
+describe('merge', () => {
+  it('only default options', () => {
+    const defaultOptions = { a: 1, b: false, c: 'test' };
+    expect(merge({}, { a: 1, b: false, c: 'test' })).toEqual(defaultOptions);
+  });
+  it('provided value takes precedence over default options', () => {
+    const defaultOptions = { a: 1, b: false, c: 'test' };
+    expect(merge({ a: 2 }, { a: 1, b: false, c: 'test' })).toEqual({
+      ...defaultOptions,
+      a: 2,
+    });
+  });
+  it('value not in options is kept, but should be a ts error', () => {
+    const defaultOptions = { a: 1, b: false, c: 'test' };
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-expect-error
+    expect(merge({ a: 2, k: 'hello' }, { a: 1, b: false, c: 'test' })).toEqual({
+      ...defaultOptions,
+      a: 2,
+      k: 'hello',
+    });
+  });
+});

--- a/src/validation/utils.ts
+++ b/src/validation/utils.ts
@@ -17,11 +17,11 @@ export function merge<T extends Record<string, unknown>>(
  */
 export function countChars(str: string) {
   const result: Record<string, number> = {};
-  for (let i = 0; i < str.length; i++) {
-    if (result[str[i]]) {
-      result[str[i]] += 1;
+  for (const char of Array.from(str)) {
+    if (result[char]) {
+      result[char] += 1;
     } else {
-      result[str[i]] = 1;
+      result[char] = 1;
     }
   }
   return result;

--- a/src/validation/utils.ts
+++ b/src/validation/utils.ts
@@ -1,0 +1,28 @@
+export function merge<T extends Record<string, unknown>>(
+  obj: Partial<T>,
+  defaults: T,
+): T {
+  for (const key in defaults) {
+    if (typeof obj[key] === 'undefined') {
+      obj[key] = defaults[key];
+    }
+  }
+  return obj as T;
+}
+
+/**
+ * Count occurrence of characters in a string
+ * @param str string to process
+ * @returns an object with character keys and values occurrence of char
+ */
+export function countChars(str: string) {
+  const result: Record<string, number> = {};
+  for (let i = 0; i < str.length; i++) {
+    if (result[str[i]]) {
+      result[str[i]] += 1;
+    } else {
+      result[str[i]] = 1;
+    }
+  }
+  return result;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,7 +1019,6 @@ __metadata:
     "@types/eslint": "npm:^9.6.1"
     "@types/js-cookie": "npm:3.0.6"
     "@types/uuid": "npm:10.0.0"
-    "@types/validator": "npm:13.12.2"
     "@typescript-eslint/eslint-plugin": "npm:8.11.0"
     "@typescript-eslint/parser": "npm:8.11.0"
     date-fns: "npm:4.1.0"
@@ -1034,7 +1033,6 @@ __metadata:
     typescript: "npm:5.6.3"
     unbuild: "npm:2.0.0"
     uuid: "npm:11.0.2"
-    validator: "npm:13.12.0"
     vite-plugin-dts: "npm:4.3.0"
     vitest: "npm:2.1.4"
   peerDependencies:
@@ -1635,13 +1633,6 @@ __metadata:
   version: 10.0.0
   resolution: "@types/uuid@npm:10.0.0"
   checksum: 10c0/9a1404bf287164481cb9b97f6bb638f78f955be57c40c6513b7655160beb29df6f84c915aaf4089a1559c216557dc4d2f79b48d978742d3ae10b937420ddac60
-  languageName: node
-  linkType: hard
-
-"@types/validator@npm:13.12.2":
-  version: 13.12.2
-  resolution: "@types/validator@npm:13.12.2"
-  checksum: 10c0/64f1326c768947d756ab5bcd73f3f11a6f07dc76292aea83890d0390a9b9acb374f8df6b24af2c783271f276d3d613b78fc79491fe87edee62108d54be2e3c31
   languageName: node
   linkType: hard
 
@@ -6347,13 +6338,6 @@ __metadata:
   bin:
     uuid: dist/esm/bin/uuid
   checksum: 10c0/bd0670a0d6f77f1932da7544c51c32ceb467f3835382df2265f3275c4981d32c136a08a4369fb027ecfffd0b2ae48f19a28266ef636c7347264d5720e85d5ba0
-  languageName: node
-  linkType: hard
-
-"validator@npm:13.12.0":
-  version: 13.12.0
-  resolution: "validator@npm:13.12.0"
-  checksum: 10c0/21d48a7947c9e8498790550f56cd7971e0e3d724c73388226b109c1bac2728f4f88caddfc2f7ed4b076f9b0d004316263ac786a17e9c4edf075741200718cd32
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In this PR I propose to remove the dependency `validator` since we only use the password checking and email checking functions. It would be easy for us to include the code of these functions in our own codebase and remove the dependency on that package. This will also allow us to properly test these functions with the inputs that seem relevant to us.

Why we should try to remove our dependency on this module is best illustrated by an image:
<img width="1673" alt="Screenshot 2024-11-04 at 09 25 22" src="https://github.com/user-attachments/assets/cf2552eb-df8b-4e45-93e0-b4713bf8e82f">
We see that in the production bundle of account, this package takes around 250Kb (rendered) of space. As we only use `isStrongPassword` and `isEmail` this seems a bit much. 