### PR TITLE
fix: strong password type

### DIFF
--- a/src/member/password.ts
+++ b/src/member/password.ts
@@ -1,10 +1,11 @@
 import { isStrongPassword } from '@/validation/isPasswordStrong.js';
 
-export const isPasswordStrong = (password: string) =>
-  isStrongPassword(password, {
+export const isPasswordStrong = (password: string): boolean => {
+  return isStrongPassword(password, {
     minLength: 8,
     minLowercase: 1,
     minUppercase: 1,
     minNumbers: 1,
     minSymbols: 0,
   });
+};

--- a/src/validation/isPasswordStrong.ts
+++ b/src/validation/isPasswordStrong.ts
@@ -15,7 +15,6 @@ const defaultOptions = {
   minUppercase: 1,
   minNumbers: 1,
   minSymbols: 1,
-  returnScore: false,
   pointsPerUnique: 1,
   pointsPerRepeat: 0.5,
   pointsForContainingLower: 10,
@@ -83,15 +82,33 @@ function scorePassword(
   return points;
 }
 
+/**
+ * Score the password based on the requirements
+ * @param str input password string
+ * @param options define password requirements that need to be met
+ * @returns the password score
+ */
+export function getPasswordScore(
+  str: string,
+  options: Partial<PasswordOptions>,
+): number {
+  const analysis = analyzePassword(str);
+  const newOptions = merge(options || {}, defaultOptions);
+  return scorePassword(analysis, newOptions);
+}
+
+/**
+ * Validate if password follows the requirements
+ * @param str input password string
+ * @param options defines requirements to be met by the password
+ * @returns whether the password is strong according to the requirements
+ */
 export function isStrongPassword(
   str: string,
   options: Partial<PasswordOptions>,
 ) {
   const analysis = analyzePassword(str);
   const newOptions = merge(options || {}, defaultOptions);
-  if (newOptions.returnScore) {
-    return scorePassword(analysis, newOptions);
-  }
   return (
     analysis.length >= newOptions.minLength &&
     analysis.lowercaseCount >= newOptions.minLowercase &&


### PR DESCRIPTION
In this PR I fix a type issue with the recently refactored `isStrongPassword` function. 

This function as ported from the `validator.js` package was accepting an `options` parameter that could contain the `returnScore` option. If this was present it would return the score of the password. So the signature of the function was `number | boolean`. I think this does not makes sens with the name of the function `is*` where we expect it to return `boolean` exclusively. So I split the functionality in two functions: `isStrongPassword` and `getPasswordScore` that have their own purpose. 