### PR TITLE
feat: add url to FileItemProperties

### DIFF
--- a/src/item/fileItem/fileItem.factory.test.ts
+++ b/src/item/fileItem/fileItem.factory.test.ts
@@ -18,6 +18,7 @@ describe('FileItemFactory', () => {
       expect(item.extra.file.altText.length).toBeGreaterThan(1);
     }
     expect(item.extra.file.content.length).toBeGreaterThan(3);
+    expect(item.extra.file.url?.length).toBeGreaterThan(3);
     expect(item.type).toEqual(ItemType.FILE);
     expect(item.extra.file.size).toBeGreaterThanOrEqual(1);
   });
@@ -30,6 +31,7 @@ describe('FileItemFactory', () => {
           mimetype: 'mimetype',
           path: 'path',
           size: 1,
+          url: 'url',
         },
       },
     });
@@ -38,6 +40,7 @@ describe('FileItemFactory', () => {
     expect(item.extra.file.path).toEqual('path');
     expect(item.extra.file.altText).toBeUndefined();
     expect(item.extra.file.content).toEqual('content');
+    expect(item.extra.file.url).toEqual('url');
     expect(item.type).toEqual(ItemType.FILE);
     expect(item.extra.file.size).toEqual(1);
   });

--- a/src/item/fileItem/fileItem.factory.ts
+++ b/src/item/fileItem/fileItem.factory.ts
@@ -27,6 +27,7 @@ export const FileItemFactory = (
         size: faker.number.int({ max: 100, min: 1 }),
         altText: faker.helpers.arrayElement([undefined, faker.lorem.word()]),
         content: faker.lorem.text(),
+        url: faker.internet.url(),
       },
     },
   };

--- a/src/item/fileItem/fileItem.ts
+++ b/src/item/fileItem/fileItem.ts
@@ -18,6 +18,7 @@ export type FileItemProperties = {
   size: number;
   altText?: string;
   content: string;
+  url?: string;
 };
 
 export type FileItemMetadata = {


### PR DESCRIPTION
File items can now include `extra.file.url` as response-only data. Refer to issue #2082 in graasp-api and issue #1248 in client.

- `FileItemProperties` with optional `url`
- `FileItemFactory` to generate a mock URL

This is needed so client Cypress fixtures can use `buildFileExtra` with `url`.